### PR TITLE
filtering removed rules from stylesheet

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,6 +226,9 @@ function compress(str, options) {
       }
     });
 
+    // filter removed rules
+    tree.rules = tree.rules.filter(function(rule) { return !!rule; });
+
     return tree;
   }
 


### PR DESCRIPTION
otherwise undefined values on the rules array causes errors when calling css-stringify
