### PR TITLE
Fix regex bug giving TypeError in compressIdentifier

### DIFF
--- a/dist/css-condense.js
+++ b/dist/css-condense.js
@@ -459,7 +459,7 @@
         if (m) {
           return "url(" + m[1] + ")";
         }
-        m = identifier.match(/^(\.?[0-9]+|[0-9]+\.[0-9]+)?(%|em|ex|in|cm|mm|pt|pc|px)$/);
+        m = identifier.match(/^(\.?[0-9]+|[0-9]+\.[0-9]+)(%|em|ex|in|cm|mm|pt|pc|px)$/);
         if (m) {
           var num = m[1];
           var unit = m[2];


### PR DESCRIPTION
There is a bug in the regular expression used in compressIdentifier: the numeric part of the identifier match is optional. If an identifier such as `em` or `px` is encountered without a number before the unit, `num = m[1]` is undefined and calling `num.match(...)` throws a `TypeError`.

Fixed by making the first matching group required, as there's nothing to compress if there's no value.
